### PR TITLE
Fix GitHubFaucet security vulnerabilities

### DIFF
--- a/contracts/script/DeployFaucet.s.sol
+++ b/contracts/script/DeployFaucet.s.sol
@@ -7,11 +7,13 @@ import {GitHubFaucet} from "../examples/GitHubFaucet.sol";
 contract DeployFaucet is Script {
     function run() external {
         address verifier = 0x0Af922925AE3602b0dC23c4cFCf54FABe2F54725;
+        bytes20 commitSha = bytes20(vm.envOr("COMMIT_SHA", bytes20(0)));
 
         vm.startBroadcast();
-        GitHubFaucet faucet = new GitHubFaucet(verifier);
+        GitHubFaucet faucet = new GitHubFaucet(verifier, commitSha);
         vm.stopBroadcast();
 
         console.log("GitHubFaucet deployed at:", address(faucet));
+        console.log("Required commit SHA:", vm.toString(commitSha));
     }
 }

--- a/contracts/test/GitHubFaucet.t.sol
+++ b/contracts/test/GitHubFaucet.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {GitHubFaucet} from "../examples/GitHubFaucet.sol";
+import {ISigstoreVerifier} from "../src/ISigstoreVerifier.sol";
+
+contract MockSigstoreVerifier is ISigstoreVerifier {
+    bytes32 public artifactHash;
+    bytes32 public repoHash;
+    bytes20 public commitSha;
+
+    function setAttestation(bytes32 _artifact, bytes32 _repo, bytes20 _commit) external {
+        artifactHash = _artifact;
+        repoHash = _repo;
+        commitSha = _commit;
+    }
+
+    function verify(bytes calldata, bytes32[] calldata) external pure returns (bool) {
+        return true;
+    }
+
+    function verifyAndDecode(bytes calldata, bytes32[] calldata)
+        external view returns (Attestation memory)
+    {
+        return Attestation(artifactHash, repoHash, commitSha);
+    }
+
+    function decodePublicInputs(bytes32[] calldata)
+        external pure returns (Attestation memory)
+    {
+        return Attestation(bytes32(0), bytes32(0), bytes20(0));
+    }
+}
+
+contract GitHubFaucetTest is Test {
+    GitHubFaucet faucet;
+    MockSigstoreVerifier mockVerifier;
+    address owner;
+
+    function setUp() public {
+        owner = address(this);
+        mockVerifier = new MockSigstoreVerifier();
+        faucet = new GitHubFaucet(address(mockVerifier), bytes20(0));
+        vm.deal(address(faucet), 10 ether);
+        vm.warp(100 days);
+    }
+
+    // ==================== Security Tests ====================
+
+    function test_SetRequirements_RequiresOwner() public {
+        address attacker = makeAddr("attacker");
+        vm.prank(attacker);
+        vm.expectRevert(GitHubFaucet.NotOwner.selector);
+        faucet.setRequirements(bytes20(uint160(0xdead)));
+    }
+
+    function test_SetRequirements_OwnerCanSet() public {
+        faucet.setRequirements(bytes20(uint160(0xdead)));
+        assertEq(faucet.requiredCommitSha(), bytes20(uint160(0xdead)));
+    }
+
+    function test_RecipientMustMatchCertificate() public {
+        address payable alice = payable(address(0x1111111111111111111111111111111111111111));
+        address payable attacker = payable(address(0x2222222222222222222222222222222222222222));
+
+        bytes memory certificate = bytes(
+            '{"github_actor": "alice", "recipient_address": "0x1111111111111111111111111111111111111111"}'
+        );
+        mockVerifier.setAttestation(sha256(certificate), bytes32(0), bytes20(0));
+
+        vm.expectRevert(GitHubFaucet.RecipientMismatch.selector);
+        faucet.claim("", new bytes32[](0), certificate, "alice", attacker);
+    }
+
+    function test_CaseInsensitiveCooldown() public {
+        address payable alice = payable(address(0x1111111111111111111111111111111111111111));
+
+        bytes memory certLower = bytes(
+            '{"github_actor": "alice", "recipient_address": "0x1111111111111111111111111111111111111111"}'
+        );
+        mockVerifier.setAttestation(sha256(certLower), bytes32(0), bytes20(0));
+        faucet.claim("", new bytes32[](0), certLower, "alice", alice);
+
+        bytes memory certUpper = bytes(
+            '{"github_actor": "Alice", "recipient_address": "0x1111111111111111111111111111111111111111"}'
+        );
+        mockVerifier.setAttestation(sha256(certUpper), bytes32(0), bytes20(0));
+
+        vm.expectRevert(GitHubFaucet.AlreadyClaimedToday.selector);
+        faucet.claim("", new bytes32[](0), certUpper, "Alice", alice);
+    }
+
+    function test_CommitRequirementEnforced() public {
+        address payable alice = payable(address(0x1111111111111111111111111111111111111111));
+
+        faucet.setRequirements(bytes20(uint160(0x123456)));
+
+        bytes memory certificate = bytes(
+            '{"github_actor": "alice", "recipient_address": "0x1111111111111111111111111111111111111111"}'
+        );
+        mockVerifier.setAttestation(sha256(certificate), bytes32(0), bytes20(uint160(0xBAD)));
+
+        vm.expectRevert(GitHubFaucet.WrongCommit.selector);
+        faucet.claim("", new bytes32[](0), certificate, "alice", alice);
+    }
+
+    // ==================== Happy Path Tests ====================
+
+    function test_LegitimateClaimSucceeds() public {
+        address payable alice = payable(address(0x1111111111111111111111111111111111111111));
+
+        bytes memory certificate = bytes(
+            '{"github_actor": "alice", "recipient_address": "0x1111111111111111111111111111111111111111"}'
+        );
+        mockVerifier.setAttestation(sha256(certificate), bytes32(0), bytes20(0));
+
+        uint256 balanceBefore = alice.balance;
+        faucet.claim("", new bytes32[](0), certificate, "alice", alice);
+        assertGt(alice.balance, balanceBefore);
+    }
+
+    function test_ClaimWithPinnedCommit() public {
+        address payable alice = payable(address(0x1111111111111111111111111111111111111111));
+        bytes20 commit = bytes20(uint160(0xABCDEF));
+
+        faucet.setRequirements(commit);
+
+        bytes memory certificate = bytes(
+            '{"github_actor": "alice", "recipient_address": "0x1111111111111111111111111111111111111111"}'
+        );
+        mockVerifier.setAttestation(sha256(certificate), bytes32(0), commit);
+
+        uint256 balanceBefore = alice.balance;
+        faucet.claim("", new bytes32[](0), certificate, "alice", alice);
+        assertGt(alice.balance, balanceBefore);
+    }
+}

--- a/docs/SECURITY_AUDIT_FAUCET.md
+++ b/docs/SECURITY_AUDIT_FAUCET.md
@@ -1,0 +1,65 @@
+# Security Audit: GitHubFaucet
+
+**Status:** Fixed
+**Circuit changes required:** None
+
+---
+
+## Issues Found and Fixed
+
+### 1. setRequirements Had No Access Control
+**Severity:** CRITICAL → **FIXED**
+
+Added `onlyOwner` modifier. Only deployer can change commit requirements.
+
+### 2. Recipient Not Validated Against Certificate
+**Severity:** HIGH → **FIXED**
+
+Added `containsBytes` check for `recipient_address` pattern. Front-running no longer possible.
+
+### 3. Case-Sensitive Cooldown Bypass
+**Severity:** MEDIUM → **FIXED**
+
+Added `toLower()` normalization before hashing username.
+
+### 4. Username Injection via containsBytes
+**Severity:** MEDIUM → **MITIGATED**
+
+With commit pinning and access control, attacker cannot use modified workflow from their fork.
+
+---
+
+## Deployment
+
+```bash
+cd contracts
+
+# Get current commit SHA (first 20 bytes)
+COMMIT=$(git rev-parse HEAD | cut -c1-40)
+
+# Deploy with pinned commit
+forge script script/DeployFaucet.s.sol \
+  --rpc-url https://sepolia.base.org \
+  --broadcast \
+  --private-key $KEY \
+  -vvvv \
+  --env COMMIT_SHA=0x$COMMIT
+```
+
+---
+
+## Test Coverage
+
+```
+forge test --match-contract GitHubFaucetTest -v
+```
+
+| Test | Status |
+|------|--------|
+| test_SetRequirements_RequiresOwner | PASS |
+| test_SetRequirements_OwnerCanSet | PASS |
+| test_RecipientMustMatchCertificate | PASS |
+| test_CaseInsensitiveCooldown | PASS |
+| test_CommitRequirementEnforced | PASS |
+| test_LegitimateClaimSucceeds | PASS |
+| test_ClaimWithPinnedCommit | PASS |


### PR DESCRIPTION
## Summary

Fixes security vulnerabilities identified in #22.

## Changes

- Add `onlyOwner` modifier to `setRequirements()`
- Validate `recipient` parameter matches certificate's `recipient_address`
- Normalize username to lowercase before hashing (case-insensitive cooldown)
- Constructor takes initial `requiredCommitSha` parameter
- Update deploy script to accept `COMMIT_SHA` env var
- Add comprehensive test coverage
- Document findings in `docs/SECURITY_AUDIT_FAUCET.md`

## Test plan

- [x] `forge test --match-contract GitHubFaucetTest` passes (7 tests)
- [x] All existing tests still pass (12 total)
- [ ] Deploy to testnet with pinned commit
- [ ] Verify old faucet can be frozen via `setRequirements`

## Deployment

```bash
cd contracts
COMMIT_SHA=0x$(git rev-parse HEAD | cut -c1-40) forge script script/DeployFaucet.s.sol \
  --broadcast --rpc-url https://sepolia.base.org --private-key $KEY
```

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/claude-code)