### PR TITLE
Add gas and circuit cost analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ browser-container/proof-[0-9]*/
 browser-container/data/
 zk-proof/circuits/proof.json
 zk-proof/circuits/target/
+zk-proof/benchmarks/*/target/
 
 # Credentials
 browser-container/twitter-session.json

--- a/contracts/test/GasProfile.t.sol
+++ b/contracts/test/GasProfile.t.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Test, console} from "forge-std/Test.sol";
+import {HonkVerifier} from "../src/HonkVerifier.sol";
+import "../src/HonkVerifier.sol"; // import all free-standing constants/types
+
+// Harness: exposes verify() internals with gas checkpoints
+contract GasProfiledVerifier is BaseZKHonkVerifier(N, LOG_N, VK_HASH, NUMBER_OF_PUBLIC_INPUTS) {
+    function loadVerificationKey() internal pure override returns (Honk.VerificationKey memory) {
+        return HonkVerificationKey.loadVerificationKey();
+    }
+
+    struct GasBreakdown {
+        uint256 loadProof;      // VK load + proof deserialization
+        uint256 transcript;     // Fiat-Shamir challenge generation
+        uint256 delta;          // Public input delta computation
+        uint256 sumcheck;       // Sumcheck verification (LOG_N rounds)
+        uint256 shplemini;      // Shplemini (MSM + fold + pairing)
+        uint256 total;
+    }
+
+    function profileVerify(bytes calldata proof, bytes32[] calldata publicInputs)
+        external view returns (GasBreakdown memory g)
+    {
+        uint256 g0 = gasleft();
+
+        // --- Stage 1: Load VK + deserialize proof ---
+        Honk.VerificationKey memory vk = loadVerificationKey();
+        Honk.ZKProof memory p = ZKTranscriptLib.loadProof(proof, $LOG_N);
+        uint256 g1 = gasleft();
+        g.loadProof = g0 - g1;
+
+        // --- Stage 2: Fiat-Shamir transcript ---
+        ZKTranscript memory t = ZKTranscriptLib.generateTranscript(
+            p, publicInputs, $VK_HASH, $NUM_PUBLIC_INPUTS, $LOG_N
+        );
+        uint256 g2 = gasleft();
+        g.transcript = g1 - g2;
+
+        // --- Stage 3: Public input delta ---
+        t.relationParameters.publicInputsDelta = computePublicInputDelta(
+            publicInputs, p.pairingPointObject,
+            t.relationParameters.beta, t.relationParameters.gamma, 1
+        );
+        uint256 g3 = gasleft();
+        g.delta = g2 - g3;
+
+        // --- Stage 4: Sumcheck ---
+        require(verifySumcheck(p, t), "sumcheck");
+        uint256 g4 = gasleft();
+        g.sumcheck = g3 - g4;
+
+        // --- Stage 5: Shplemini (MSM + fold + pairing) ---
+        require(verifyShplemini(p, vk, t), "shplemini");
+        uint256 g5 = gasleft();
+        g.shplemini = g4 - g5;
+
+        g.total = g0 - g5;
+    }
+}
+
+contract GasProfileTest is Test {
+    GasProfiledVerifier profiler;
+    bytes proof;
+    bytes32[] publicInputs;
+
+    function setUp() public {
+        profiler = new GasProfiledVerifier();
+
+        // Load real proof + inputs
+        proof = vm.readFileBinary("test/proof.bin");
+        bytes memory inputsRaw = vm.readFileBinary("test/inputs.bin");
+        uint256 n = inputsRaw.length / 32;
+        publicInputs = new bytes32[](n);
+        for (uint i = 0; i < n; i++) {
+            bytes32 val;
+            assembly { val := mload(add(inputsRaw, add(32, mul(i, 32)))) }
+            publicInputs[i] = val;
+        }
+    }
+
+    function test_GasProfile() public view {
+        GasProfiledVerifier.GasBreakdown memory g = profiler.profileVerify(proof, publicInputs);
+
+        console.log("=== HonkVerifier Gas Profile ===");
+        console.log("Circuit size: 2^20 = 1,048,576 gates");
+        console.log("Public inputs:", publicInputs.length);
+        console.log("Proof bytes:", proof.length);
+        console.log("");
+        console.log("--- Component Breakdown ---");
+        console.log("1. Load VK + parse proof:", g.loadProof);
+        console.log("2. Fiat-Shamir transcript:", g.transcript);
+        console.log("3. Public input delta:    ", g.delta);
+        console.log("4. Sumcheck (20 rounds):  ", g.sumcheck);
+        console.log("5. Shplemini (MSM+pairing):", g.shplemini);
+        console.log("---");
+        console.log("TOTAL (internal):         ", g.total);
+        console.log("");
+
+        // Percentages (integer math, x10 for one decimal)
+        console.log("--- Percentage Breakdown ---");
+        console.log("1. Load+parse:  ", g.loadProof * 1000 / g.total, "/ 1000");
+        console.log("2. Transcript:  ", g.transcript * 1000 / g.total, "/ 1000");
+        console.log("3. Delta:       ", g.delta * 1000 / g.total, "/ 1000");
+        console.log("4. Sumcheck:    ", g.sumcheck * 1000 / g.total, "/ 1000");
+        console.log("5. Shplemini:   ", g.shplemini * 1000 / g.total, "/ 1000");
+    }
+
+    // --- Isolated precompile benchmarks ---
+
+    function test_PrecompileCost_MODEXP() public view {
+        // FrLib.invert: modexp(v, MODULUS-2, MODULUS) — field inversion
+        uint256 MODULUS = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+        uint256 v = 42;
+        uint256 g0 = gasleft();
+        assembly {
+            let free := mload(0x40)
+            mstore(free, 0x20)
+            mstore(add(free, 0x20), 0x20)
+            mstore(add(free, 0x40), 0x20)
+            mstore(add(free, 0x60), v)
+            mstore(add(free, 0x80), sub(MODULUS, 2))
+            mstore(add(free, 0xa0), MODULUS)
+            pop(staticcall(gas(), 0x05, free, 0xc0, 0x00, 0x20))
+        }
+        uint256 g1 = gasleft();
+        console.log("MODEXP (field invert) gas:", g0 - g1);
+    }
+
+    function test_PrecompileCost_ECMUL() public view {
+        // bn254 G1 generator * scalar
+        uint256 g0 = gasleft();
+        assembly {
+            let free := mload(0x40)
+            mstore(free, 1) // G1.x
+            mstore(add(free, 0x20), 2) // G1.y
+            mstore(add(free, 0x40), 7) // scalar
+            pop(staticcall(gas(), 7, free, 0x60, free, 0x40))
+        }
+        uint256 g1 = gasleft();
+        console.log("ECMUL gas:", g0 - g1);
+    }
+
+    function test_PrecompileCost_ECADD() public view {
+        // G1 + G1
+        uint256 g0 = gasleft();
+        assembly {
+            let free := mload(0x40)
+            mstore(free, 1)
+            mstore(add(free, 0x20), 2)
+            mstore(add(free, 0x40), 1)
+            mstore(add(free, 0x60), 2)
+            pop(staticcall(gas(), 6, free, 0x80, free, 0x40))
+        }
+        uint256 g1 = gasleft();
+        console.log("ECADD gas:", g0 - g1);
+    }
+
+    function test_PrecompileCost_ECPAIRING() public view {
+        // Single pairing check: e(G1, G2) == e(G1, G2)
+        uint256 g0 = gasleft();
+        assembly {
+            let free := mload(0x40)
+            // P1 (G1 generator)
+            mstore(free, 1)
+            mstore(add(free, 0x20), 2)
+            // Q1 (G2 generator)
+            mstore(add(free, 0x40), 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2)
+            mstore(add(free, 0x60), 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed)
+            mstore(add(free, 0x80), 0x090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b)
+            mstore(add(free, 0xa0), 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa)
+            // P2 = -G1 (negate y)
+            mstore(add(free, 0xc0), 1)
+            mstore(add(free, 0xe0), 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd45) // P - 2
+            // Q2 = G2 generator (same)
+            mstore(add(free, 0x100), 0x198e9393920d483a7260bfb731fb5d25f1aa493335a9e71297e485b7aef312c2)
+            mstore(add(free, 0x120), 0x1800deef121f1e76426a00665e5c4479674322d4f75edadd46debd5cd992f6ed)
+            mstore(add(free, 0x140), 0x090689d0585ff075ec9e99ad690c3395bc4b313370b38ef355acdadcd122975b)
+            mstore(add(free, 0x160), 0x12c85ea5db8c6deb4aab71808dcb408fe3d1e7690c43d37b4ce6cc0166fa7daa)
+            pop(staticcall(gas(), 8, free, 0x180, free, 0x20))
+        }
+        uint256 g1 = gasleft();
+        console.log("ECPAIRING (2 pairs) gas:", g0 - g1);
+    }
+
+    function test_PrecompileCost_Summary() public view {
+        console.log("=== Precompile Unit Costs ===");
+        console.log("These are the per-call costs of each EVM precompile.");
+        console.log("Multiply by call count to estimate component gas.");
+        console.log("");
+        console.log("Expected call counts in HonkVerifier:");
+        console.log("  MODEXP:    ~40-60x (sumcheck barycentrics + shplemini inversions)");
+        console.log("  ECMUL:     62x (MSMSize = 37 + LOG_N + 3 + 2)");
+        console.log("  ECADD:     62x (one per MSM accumulation)");
+        console.log("  ECPAIRING: 1x (final check, 2 pairs)");
+    }
+}

--- a/docs/gas-analysis.md
+++ b/docs/gas-analysis.md
@@ -1,0 +1,129 @@
+# Gas & Circuit Analysis
+
+Empirical breakdown of on-chain verification gas costs and circuit constraint
+contributions. All measurements taken with nargo 1.0.0-beta.17, barretenberg v3.0.3,
+Foundry (Cancun EVM), optimizer_runs=1.
+
+Reproduce with:
+```bash
+# On-chain gas profile
+cd contracts && forge test --match-contract GasProfileTest -vv
+
+# Circuit constraint counts (per-component)
+cd zk-proof/benchmarks/<name> && nargo info
+```
+
+---
+
+## On-Chain Verification Gas (2,825,166 total)
+
+Measured via `contracts/test/GasProfile.t.sol`. The test contract inherits from
+`BaseZKHonkVerifier` and inserts `gasleft()` checkpoints between each verification stage.
+
+| # | Component | Gas | % |
+|---|-----------|-----|---|
+| 1 | Load VK + parse proof | 227,965 | 8.1% |
+| 2 | Fiat-Shamir transcript (keccak256) | 310,881 | 11.0% |
+| 3 | Public input delta (100 field muls) | 86,707 | 3.1% |
+| 4 | Sumcheck (20 rounds, barycentric eval) | 599,934 | 21.2% |
+| 5 | Shplemini (62-point MSM + fold + pairing) | 1,599,679 | 56.6% |
+
+### EVM Precompile Unit Costs
+
+| Precompile | Address | Gas/call | Calls in verifier |
+|------------|---------|----------|-------------------|
+| MODEXP (field invert) | 0x05 | 1,595 | ~50 (sumcheck + shplemini) |
+| ECMUL (scalar mul) | 0x07 | 6,187 | 62 (MSMSize) |
+| ECADD (point add) | 0x06 | 355 | 62 |
+| ECPAIRING (2 pairs) | 0x08 | 113,581 | 1 |
+
+### Key Constants
+
+```
+N            = 2^20 = 1,048,576 gates
+LOG_N        = 20
+PUBLIC_INPUTS = 100 (84 attestation data + 16 pairing points)
+MSMSize      = NUMBER_UNSHIFTED_ZK + LOG_N + LIBRA_COMMITMENTS + 2
+             = 37 + 20 + 3 + 2 = 62
+Proof size   = 10,560 bytes (330 field elements × 32 bytes)
+```
+
+### Scaling
+
+Verification gas scales **O(log N)** — NOT linearly in circuit size or witness size.
+Doubling the circuit from 2^20 → 2^21 adds ~1 ECMUL (6.2K) + ~1 sumcheck round (30K)
+≈ 36K extra gas (~1.3%).
+
+The 2.83M gas is essentially fixed protocol overhead, dominated by EVM precompile calls
+in the Shplemini polynomial commitment check.
+
+### Full Transaction Cost
+
+| Layer | Gas |
+|-------|-----|
+| HonkVerifier.verify() | 2,827,449 |
+| SigstoreVerifier.verify() (wrapper) | 2,834,235 |
+| GitHubFaucet.claim() (app logic) | ~120,880 |
+| **Full claim transaction** | **~2,950,000** |
+
+---
+
+## Circuit Constraint Breakdown
+
+The ZK circuit verifies a full Sigstore certificate chain: intermediate CA (P-384) →
+leaf cert (P-256) → DSSE attestation. Each cryptographic operation contributes a
+measurable number of constraints.
+
+Measured via isolated benchmark circuits in `zk-proof/benchmarks/`. Each benchmark
+contains a single cryptographic operation compiled independently with `nargo info`.
+
+| Component | Expression Width | ACIR Opcodes | % of circuit |
+|-----------|-----------------|--------------|--------------|
+| **SHA-384** (1800 bytes, cert TBS) | 198,064 | 650 | **65.2%** |
+| **P-384 ECDSA** verify | 66,813 | 255,723 | **22.0%** |
+| **SHA-256** (2048 bytes, PAE msg) | 30,839 | 2,560 | **10.1%** |
+| SHA-256 (64 bytes, repo name) | 1,730 | 575 | 0.6% |
+| P-256 ECDSA verify (blackbox) | 162 | 0 | <0.1% |
+| Hex decode + comparisons | — | — | ~2% |
+| **Full circuit** | **303,899** | **256,771** | **100%** |
+
+### Interpretation
+
+**SHA-384 dominates at 65%.** This is because:
+- SHA-384 operates on 64-bit words → expensive in a ~254-bit prime field circuit
+- 1800 bytes of input requires ~14 compression rounds (128-byte blocks)
+- The `sha512` library (which implements SHA-384) is constraint-heavy in Noir
+
+**P-384 ECDSA is 22%.** Elliptic curve scalar multiplication over a 384-bit field
+requires extensive bignum arithmetic (modular multiplication, inversion, point
+addition/doubling).
+
+**SHA-256 (2048 bytes) is 10%.** SHA-256 uses 32-bit words — much cheaper per round
+than SHA-384. But 2048 bytes still requires ~32 compression rounds.
+
+**P-256 ECDSA is near-zero in ACIR.** It's a Noir **blackbox function** — the backend
+(barretenberg) implements it natively. The 162 expression width is just I/O marshalling.
+The real gate contribution is hidden inside the backend.
+
+### What the Full Circuit Does
+
+```
+Step 1: SHA-384(leaf_tbs, 1800 bytes)         ← 65% of constraints
+Step 2: P-384 ECDSA verify(intermediate_sig)  ← 22% of constraints
+Step 3: Extract P-256 pubkey from TBS
+Step 4: SHA-256(pae_message, 2048 bytes)       ← 10% of constraints
+Step 5: P-256 ECDSA verify(leaf_sig)           ← blackbox (backend-native)
+Step 6: Extract & verify commit SHA, repo, artifact hash
+Step 7: SHA-256(repo_name, 64 bytes)           ← 0.6% of constraints
+```
+
+### Optimization Opportunities
+
+If circuit size reduction is needed:
+1. **SHA-384 → SHA-256** — would save ~65% of constraints, but requires Sigstore
+   to change their cert signing algorithm (not feasible)
+2. **Reduce MAX_TBS_LENGTH** — 1800→1200 bytes could save ~20% of SHA-384 cost
+   if certs are consistently smaller
+3. **Reduce MAX_PAE_LENGTH** — 2048→1024 bytes saves ~5% of total
+4. **Note:** Reducing circuit size has minimal impact on on-chain gas (O(log N))
+   but directly reduces prover time and memory

--- a/zk-proof/benchmarks/p256_verify/Nargo.toml
+++ b/zk-proof/benchmarks/p256_verify/Nargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "bench_p256_verify"
+type = "bin"
+compiler_version = ">=1.0.0"

--- a/zk-proof/benchmarks/p256_verify/src/main.nr
+++ b/zk-proof/benchmarks/p256_verify/src/main.nr
@@ -1,0 +1,11 @@
+use std::ecdsa_secp256r1;
+
+fn main(
+    pub_key_x: [u8; 32],
+    pub_key_y: [u8; 32],
+    signature: [u8; 64],
+    msg_hash: pub [u8; 32],
+) {
+    let valid = ecdsa_secp256r1::verify_signature(pub_key_x, pub_key_y, signature, msg_hash);
+    assert(valid);
+}

--- a/zk-proof/benchmarks/p384_verify/Nargo.toml
+++ b/zk-proof/benchmarks/p384_verify/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bench_p384_verify"
+type = "bin"
+compiler_version = ">=1.0.0"
+
+[dependencies]
+ecdsa = { tag = "v0.2.9", git = "https://github.com/zkpassport/noir-ecdsa" }
+bignum = { tag = "v0.8.0-2", git = "https://github.com/zkpassport/noir-bignum" }
+bigcurve = { tag = "v0.11.0-1", git = "https://github.com/zkpassport/noir_bigcurve" }

--- a/zk-proof/benchmarks/p384_verify/src/main.nr
+++ b/zk-proof/benchmarks/p384_verify/src/main.nr
@@ -1,0 +1,19 @@
+use bignum::bignum::BigNum;
+use bignum::fields::secp384r1Fq::Secp384r1_Fq;
+use bignum::fields::secp384r1Fr::Secp384r1_Fr;
+use ecdsa::ecdsa::verify_secp384r1_ecdsa;
+
+fn main(
+    pubkey_x: [u8; 48],
+    pubkey_y: [u8; 48],
+    sig_r: [u8; 48],
+    sig_s: [u8; 48],
+    msg_hash: pub [u8; 48],
+) {
+    let pubkey_x_bn: Secp384r1_Fq = Secp384r1_Fq::from_be_bytes(pubkey_x);
+    let pubkey_y_bn: Secp384r1_Fq = Secp384r1_Fq::from_be_bytes(pubkey_y);
+    let sig_r_bn: Secp384r1_Fr = Secp384r1_Fr::from_be_bytes(sig_r);
+    let sig_s_bn: Secp384r1_Fr = Secp384r1_Fr::from_be_bytes(sig_s);
+    let valid = verify_secp384r1_ecdsa(pubkey_x_bn, pubkey_y_bn, msg_hash, (sig_r_bn, sig_s_bn));
+    assert(valid);
+}

--- a/zk-proof/benchmarks/sha256_2048/Nargo.toml
+++ b/zk-proof/benchmarks/sha256_2048/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bench_sha256_2048"
+type = "bin"
+compiler_version = ">=1.0.0"
+
+[dependencies]
+sha256 = { tag = "v0.2.1", git = "https://github.com/noir-lang/sha256" }

--- a/zk-proof/benchmarks/sha256_2048/src/main.nr
+++ b/zk-proof/benchmarks/sha256_2048/src/main.nr
@@ -1,0 +1,6 @@
+use sha256::sha256_var;
+
+fn main(data: [u8; 2048], data_len: u32, expected: pub [u8; 32]) {
+    let hash = sha256_var(data, data_len as u64);
+    assert(hash == expected);
+}

--- a/zk-proof/benchmarks/sha256_64/Nargo.toml
+++ b/zk-proof/benchmarks/sha256_64/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bench_sha256_64"
+type = "bin"
+compiler_version = ">=1.0.0"
+
+[dependencies]
+sha256 = { tag = "v0.2.1", git = "https://github.com/noir-lang/sha256" }

--- a/zk-proof/benchmarks/sha256_64/src/main.nr
+++ b/zk-proof/benchmarks/sha256_64/src/main.nr
@@ -1,0 +1,6 @@
+use sha256::sha256_var;
+
+fn main(data: [u8; 64], data_len: u32, expected: pub [u8; 32]) {
+    let hash = sha256_var(data, data_len as u64);
+    assert(hash == expected);
+}

--- a/zk-proof/benchmarks/sha384_1800/Nargo.toml
+++ b/zk-proof/benchmarks/sha384_1800/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bench_sha384_1800"
+type = "bin"
+compiler_version = ">=1.0.0"
+
+[dependencies]
+sha512 = { tag = "v0.1.0", git = "https://github.com/zkpassport/sha512" }

--- a/zk-proof/benchmarks/sha384_1800/src/main.nr
+++ b/zk-proof/benchmarks/sha384_1800/src/main.nr
@@ -1,0 +1,7 @@
+use sha512::sha384;
+
+fn main(data: [u8; 1800], data_len: u32, expected: pub [u8; 48]) {
+    let data_vec = BoundedVec::from_parts_unchecked(data, data_len);
+    let hash: [u8; 48] = sha384::sha384_var(data_vec);
+    assert(hash == expected);
+}


### PR DESCRIPTION
## Summary

- Empirical gas breakdown of on-chain HonkVerifier via instrumented test harness (`gasleft()` checkpoints)
- Circuit constraint breakdown via isolated Noir benchmark circuits for each crypto primitive
- Full analysis documented in `docs/gas-analysis.md`

### On-chain verification: 2.83M gas

| Component | Gas | % |
|---|---|---|
| Shplemini (62-pt MSM + fold + pairing) | 1,599,679 | 56.6% |
| Sumcheck (20 rounds) | 599,934 | 21.2% |
| Fiat-Shamir transcript | 310,881 | 11.0% |
| Load VK + parse proof | 227,965 | 8.1% |
| Public input delta | 86,707 | 3.1% |

Scales **O(log N)** in circuit size — doubling gates adds ~1.3% gas.

### Circuit constraints: 303,899 expression width

| Component | Constraints | % |
|---|---|---|
| SHA-384 (1800 byte cert TBS) | 198,064 | 65.2% |
| P-384 ECDSA verify | 66,813 | 22.0% |
| SHA-256 (2048 byte PAE) | 30,839 | 10.1% |
| SHA-256 (64 byte repo name) | 1,730 | 0.6% |
| P-256 ECDSA (blackbox) | 162 | <0.1% |

SHA-384 dominates because 64-bit word ops are expensive in a ~254-bit field circuit.

## Test plan

- [x] `forge test --match-contract GasProfileTest -vv` — 6/6 pass
- [x] `nargo info` on each benchmark circuit compiles and reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)