### PR TITLE
fix: raise faucet claim relay gas limit

### DIFF
--- a/.github/workflows/process-claim.yml
+++ b/.github/workflows/process-claim.yml
@@ -113,7 +113,7 @@ jobs:
             "${{ steps.parse.outputs.recipient }}" \
             --private-key "$RELAYER_KEY" \
             --rpc-url https://sepolia.base.org \
-            --gas-limit 3500000 \
+            --gas-limit 6000000 \
             --json 2>&1)
           EXIT_CODE=$?
           set -e


### PR DESCRIPTION
The issue relayer currently hardcodes `--gas-limit 3500000` for `GitHubFaucet.claim(...)`. A recent valid claim reached the contract but reverted on-chain with receipt `status: 0x0`:

- failed tx: https://sepolia.basescan.org/tx/0x995d7f4dffa7de83aef80935c14d78af18bc87be1d20f8878adf0565c40dc2c5
- failed claim issue: #114
- relay gas limit: 3,500,000
- `cast estimate` for the same calldata/from address: 4,632,220
- `canClaim("G-structure")`: true
- `claimAmount()`: 0.001 ETH
- required commit matches the `v1.0.3` workflow head SHA

This bumps the relay gas cap to 6,000,000 so the proof-verifier path has enough headroom. The contract still enforces proof validity, recipient binding, cooldown, and faucet balance checks on-chain; this only gives the relay enough gas to reach those checks reliably.